### PR TITLE
Enable Essentials integration in Towny

### DIFF
--- a/Towny/settings/config.yml
+++ b/Towny/settings/config.yml
@@ -423,7 +423,7 @@ plugin:
       fake_residents: '[IndustrialCraft],[BuildCraft],[Redpower],[Forestry],[Turtle]'
  
     # Enable using_essentials if you are using cooldowns in essentials for teleports.
-    using_essentials: 'false'
+    using_essentials: 'true'
  
     # This will attempt to use Register (if present)
     # Then it will attempt to access iConomy 5.01 directly


### PR DESCRIPTION
This will also apply Essentials teleport delays in Towny teleports.
