### PR TITLE
Don't limit furnaces for server members

### DIFF
--- a/PermissionsEx/permissions.yml
+++ b/PermissionsEx/permissions.yml
@@ -73,6 +73,7 @@ groups:
     inheritance:
     - default
     permissions:
+    - jobs.maxfurnaces.19042
     - essentials.motd
     - movecraft.*
     - essentials.warp


### PR DESCRIPTION
Instead of changing the default value in the config, giving permission to server members to practically use as many furnaces as they need. Just to be sure, newcomers can still only use 20 furnaces.