### PR TITLE
Block sinking on pvp = false

### DIFF
--- a/Movecraft/config.yml
+++ b/Movecraft/config.yml
@@ -23,7 +23,7 @@ WGCustomFlagsUseMoveFlag: false
 WGCustomFlagsUseRotateFlag: false
 WGCustomFlagsUseSinkFlag: false
 TownyBlockMoveOnSwitchPerm: false
-TownyBlockSinkOnNoPVP: false
+TownyBlockSinkOnNoPVP: true
 TownyWorldHeightLimits:
   world:
     underTownSpawn: 255


### PR DESCRIPTION
Might fix movecraft explosives damaging towns with PvP enabled?